### PR TITLE
Fix readme.md's typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 ## Getting Started
 ```sh
 # Installation with package manager
-$ yarn add react react-dom react-google-ades
+$ yarn add react react-dom react-google-ads
 # or..
-$ npm i -S react react-dom react-google-ades
+$ npm i -S react react-dom react-google-ads
 ```
 
 ## Development


### PR DESCRIPTION
In getting started section, I think the command should be `react-google-ads`.

I've try to `npm i -S react-google-ades` but not working.
```
$ npm i -S react-google-ades
npm ERR! code E404
npm ERR! 404 Not Found: react-google-ades@latest

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/dc_hideokamoto/.npm/_logs/2018-04-02T14_48_42_089Z-debug.log
```